### PR TITLE
Feature/Spring Security oauth2로 소셜 로그인 구현하기 (Google,Naver,Kakao)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ Temporary Items
 
 # SECRET KEY
 **/src/main/resources/secret.key
+**/src/main/resources/keys/

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5' // 실제 구현체 (JWT 생성,서명,검증 기능)
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JWT 페이로드를 JSON 형식으로 처리
 
+	// oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tistory/framework/security/config/SecurityConfig.java
+++ b/src/main/java/com/tistory/framework/security/config/SecurityConfig.java
@@ -42,10 +42,10 @@ public class SecurityConfig {
                 )
 //                .httpBasic(withDefaults()) // HTTP Basic 인증 활성화 -> 주로 간단한 테스트를 위해 사용됨. JWT토큰 인증을 사용하면 없어도 됨
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 추가
-                .oauth2Login(oauth2 -> oauth2 // OAuth2
+                .oauth2Login(oauth2 -> oauth2 // OAuth2 로그인 기능 활성화
                         .userInfoEndpoint(userInfo -> userInfo // 사용자 정보 엔드포인트 설정
-                                .userService(customOAuth2UserService))
-                        .successHandler(customAuthenticationSuccessHandler)) // 사용자 서비스 설정
+                                .userService(customOAuth2UserService)) // 사용자 정보 로드,저장,업데이트
+                        .successHandler(customAuthenticationSuccessHandler)) // OAuth2 로그인 성공 후 수행 동작 정의
                 .cors(cors -> cors.disable()) // cors 비활성화: 외부에서 해당 애플리케이션 리소스에 접근할 수 있게 해주는 보안 기능
                 .csrf(csrf -> csrf.disable());
         return http.build(); // HTTP 보안 설정을 빌드하여 반환

--- a/src/main/java/com/tistory/framework/security/config/SecurityConfig.java
+++ b/src/main/java/com/tistory/framework/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.tistory.framework.security.config;
 
+import com.tistory.framework.security.handler.CustomAuthenticationSuccessHandler;
+import com.tistory.framework.security.service.CustomOAuth2UserService;
 import com.tistory.framework.security.filter.JwtRequestFilter;
 import com.tistory.framework.security.service.CustomUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +25,12 @@ public class SecurityConfig {
     @Autowired
     private JwtRequestFilter jwtRequestFilter;
 
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Autowired
+    private CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+
     // HTTP 보안 설정을 구성하는 메서드
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,6 +42,10 @@ public class SecurityConfig {
                 )
 //                .httpBasic(withDefaults()) // HTTP Basic 인증 활성화 -> 주로 간단한 테스트를 위해 사용됨. JWT토큰 인증을 사용하면 없어도 됨
                 .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class) // JWT 필터 추가
+                .oauth2Login(oauth2 -> oauth2 // OAuth2
+                        .userInfoEndpoint(userInfo -> userInfo // 사용자 정보 엔드포인트 설정
+                                .userService(customOAuth2UserService))
+                        .successHandler(customAuthenticationSuccessHandler)) // 사용자 서비스 설정
                 .cors(cors -> cors.disable()) // cors 비활성화: 외부에서 해당 애플리케이션 리소스에 접근할 수 있게 해주는 보안 기능
                 .csrf(csrf -> csrf.disable());
         return http.build(); // HTTP 보안 설정을 빌드하여 반환
@@ -55,4 +67,5 @@ public class SecurityConfig {
                 .passwordEncoder(passwordEncoder());    // 비밀번호 검증
         return authenticationManagerBuilder.build();
     }
+
 }

--- a/src/main/java/com/tistory/framework/security/dto/CustomOAuth2User.java
+++ b/src/main/java/com/tistory/framework/security/dto/CustomOAuth2User.java
@@ -6,6 +6,9 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import java.util.Collection;
 import java.util.Map;
 
+/**
+ * OAuth2 인증 후에 사용자 정보와 JWT 토큰을 포함하는 커스텀 OAuth2User 객체
+ */
 public class CustomOAuth2User implements OAuth2User {
     private final OAuth2User oAuth2User;
     private final String jwtToken;
@@ -15,23 +18,30 @@ public class CustomOAuth2User implements OAuth2User {
         this.jwtToken = jwtToken;
     }
 
+    // 기존 OAuth2User의 속성에 JWT 토큰을 추가하여 반환
     @Override
     public Map<String, Object> getAttributes() {
+        // 기존 OAuth2User의 속성을 가져와서 새로운 HashMap에 복사
         Map<String, Object> attributes = new java.util.HashMap<>(oAuth2User.getAttributes());
+        // JWT 토큰을 추가
         attributes.put("jwtToken", jwtToken);
         return attributes;
     }
 
+    // 사용자의 권한을 반환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 기존 OAuth2User의 권한을 반환
         return oAuth2User.getAuthorities();
     }
 
+    // 사용자의 이름을 반환
     @Override
     public String getName() {
         return oAuth2User.getName();
     }
 
+    // JWT 토큰을 반환
     public String getJwtToken() {
         return jwtToken;
     }

--- a/src/main/java/com/tistory/framework/security/dto/CustomOAuth2User.java
+++ b/src/main/java/com/tistory/framework/security/dto/CustomOAuth2User.java
@@ -1,0 +1,38 @@
+package com.tistory.framework.security.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+    private final OAuth2User oAuth2User;
+    private final String jwtToken;
+
+    public CustomOAuth2User(OAuth2User oAuth2User, String jwtToken) {
+        this.oAuth2User = oAuth2User;
+        this.jwtToken = jwtToken;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        Map<String, Object> attributes = new java.util.HashMap<>(oAuth2User.getAttributes());
+        attributes.put("jwtToken", jwtToken);
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return oAuth2User.getAuthorities();
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2User.getName();
+    }
+
+    public String getJwtToken() {
+        return jwtToken;
+    }
+}

--- a/src/main/java/com/tistory/framework/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/tistory/framework/security/handler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,32 @@
+package com.tistory.framework.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tistory.framework.security.dto.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String jwtToken = oAuth2User.getJwtToken();
+
+        Map<String, String> tokenMap = new HashMap<>();
+        tokenMap.put("jwtToken", jwtToken);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(tokenMap));
+    }
+}

--- a/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
@@ -58,9 +58,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
         String jwtToken = jwtTokenUtil.generateToken(userDetails);
 
-        log.error("@@CustomOAuth2UserService jwtToken:{}", jwtToken);
         // JWT 토큰을 사용자 정보에 추가
         return new CustomOAuth2User(oAuth2User, jwtToken);
-
     }
 }

--- a/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
@@ -4,7 +4,9 @@ import com.tistory.framework.security.dto.CustomOAuth2User;
 import com.tistory.framework.security.dto.CustomUserDetails;
 import com.tistory.framework.security.utils.JwtTokenUtil;
 import com.tistory.project_api.dto.UserDto;
+import com.tistory.project_api.dto.UserOauth2ProvidersDto;
 import com.tistory.project_api.mapper.UserMapper;
+import com.tistory.project_api.mapper.UserOauth2ProvidersMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -13,11 +15,17 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @Slf4j
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
     @Autowired
-    UserMapper userMapper;
+    private UserMapper userMapper;
+
+    @Autowired
+    private UserOauth2ProvidersMapper userOauth2ProvidersMapper;
 
     @Autowired
     private JwtTokenUtil jwtTokenUtil;
@@ -25,40 +33,191 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Autowired
     private CustomUserDetailsService customUserDetailsService;
 
-    // OAuth2 로그인 후 사용자 정보를 로드
+    private static final String NAVER = "naver";
+    private static final String KAKAO = "kakao";
+    private static final String GOOGLE = "google";
+    private static final String RESPONSE = "response";
+    private static final String KAKAO_ACCOUNT = "kakao_account";
+    private static final String PROFILE = "profile";
+    private static final String EMAIL = "email";
+    private static final String NAME = "name";
+    private static final String ID = "id";
+    private static final String NICKNAME = "nickname";
+
+    /**
+     * OAuth2 로그인 후 사용자 정보를 로드
+     * @param userRequest the OAuth2 user request
+     * @return the OAuth2User with JWT token
+     * @throws OAuth2AuthenticationException if an authentication error occurs
+     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
+        UserAttributes userAttributes = extractUserAttributes(userRequest, oAuth2User);
+        processUser(userAttributes);
+        CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(userAttributes.getEmail());
+        String jwtToken = jwtTokenUtil.generateToken(userDetails);
+        return new CustomOAuth2User(oAuth2User, jwtToken);
+    }
 
-        // 구글 OAuth2 제공자 ID 가져오기
+    /**
+     * 사용자 요청과 OAuth2 사용자로부터 사용자 속성을 추출
+     * @param userRequest the OAuth2 user request
+     * @param oAuth2User the OAuth2 user
+     * @return the extracted UserAttributes
+     */
+    private UserAttributes extractUserAttributes(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
         String oauth2Provider = userRequest.getClientRegistration().getRegistrationId();
-        String oauth2ProviderId = oAuth2User.getName();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
 
-        // 사용자 정보를 가져와서 데이터베이스에 저장
-        String email = oAuth2User.getAttribute("email");
-        String name = oAuth2User.getAttribute("name");
+        switch (oauth2Provider) {
+            case NAVER:
+                return extractNaverAttributes(attributes);
+            case KAKAO:
+                return extractKakaoAttributes(attributes, oAuth2User);
+            case GOOGLE:
+                return extractGoogleAttributes(attributes, oAuth2User);
+            default:
+                throw new OAuth2AuthenticationException("Unsupported OAuth2 provider: " + oauth2Provider);
+        }
+    }
 
-        // 사용자 정보 저장 또는 업데이트
+    /**
+     * 네이버 사용자 속성을 추출
+     * @param attributes the OAuth2 user attributes
+     * @return the extracted UserAttributes
+     */
+    private UserAttributes extractNaverAttributes(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get(RESPONSE);
+        return new UserAttributes(
+                (String) response.get(EMAIL),
+                (String) response.get(NAME),
+                NAVER,
+                (String) response.get(ID)
+        );
+    }
+
+    /**
+     * 카카오 사용자 속성을 추출
+     * @param attributes the OAuth2 user attributes
+     * @param oAuth2User the OAuth2 user
+     * @return the extracted UserAttributes
+     */
+    private UserAttributes extractKakaoAttributes(Map<String, Object> attributes, OAuth2User oAuth2User) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get(KAKAO_ACCOUNT);
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get(PROFILE);
+        return new UserAttributes(
+                (String) kakaoAccount.get(EMAIL),
+                (String) kakaoProfile.get(NICKNAME),
+                KAKAO,
+                oAuth2User.getName()
+        );
+    }
+
+    /**
+     * 구글 사용자 속성을 추출
+     * @param attributes the OAuth2 user attributes
+     * @param oAuth2User the OAuth2 user
+     * @return the extracted UserAttributes
+     */
+    private UserAttributes extractGoogleAttributes(Map<String, Object> attributes, OAuth2User oAuth2User) {
+        return new UserAttributes(
+                (String) attributes.get(EMAIL),
+                (String) attributes.get(NAME),
+                GOOGLE,
+                oAuth2User.getName()
+        );
+    }
+
+    /**
+     * 사용자 정보 처리 (생성 or 업데이트 or 통합)
+     * @param userAttributes the user attributes
+     */
+    private void processUser(UserAttributes userAttributes) {
         UserDto.UserBase user = userMapper.findByEmail(UserDto.UserSearchByEmailCondition.builder()
-                .email(email).build());
-        if (user == null) {
-            UserDto.SocialSignUp dto = UserDto.SocialSignUp.builder()
-                    .username(name)
-                    .email(email)
-                    .oauth2Provider(oauth2Provider)
-                    .oauth2ProviderId(oauth2ProviderId)
-                    .build();
-            userMapper.socialSignUp(dto);
-        } else {
-            // 기존 사용자 업데이트
+                .email(userAttributes.getEmail())
+                .build());
 
+        if (user == null) {
+            registerNewUser(userAttributes);
+        } else {
+            checkAndAddOauthProvider(userAttributes);
+        }
+    }
+
+    /**
+     * 새로운 사용자를 등록
+     * @param userAttributes the user attributes
+     */
+    private void registerNewUser(UserAttributes userAttributes) {
+        UserDto.SignUp signUpDto = UserDto.SignUp.builder()
+                .username(userAttributes.getName())
+                .email(userAttributes.getEmail())
+                .build();
+        userMapper.signUp(signUpDto);
+
+        addUserProvider(userAttributes);
+    }
+
+    /**
+     * 사용자가 기존에 등록되어 있는지 확인하고 OAuth2 provider를 추가
+     * @param userAttributes the user attributes
+     */
+    private void checkAndAddOauthProvider(UserAttributes userAttributes) {
+        UserOauth2ProvidersDto.UserOauth2ProviderBase existUser = userOauth2ProvidersMapper.findByEmailProvider(
+                UserOauth2ProvidersDto.UserProviderCondition.builder()
+                        .email(userAttributes.getEmail())
+                        .provider(userAttributes.getOauth2Provider())
+                        .build());
+
+        if (existUser == null) {
+            addUserProvider(userAttributes);
+        }
+    }
+
+    /**
+     * OAuth2 provider를 사용자에게 추가
+     * @param userAttributes the user attributes
+     */
+    private void addUserProvider(UserAttributes userAttributes) {
+        UserOauth2ProvidersDto.AddUserOauth2Provider providerDto = UserOauth2ProvidersDto.AddUserOauth2Provider.builder()
+                .email(userAttributes.getEmail())
+                .provider(userAttributes.getOauth2Provider())
+                .providerId(userAttributes.getOauth2ProviderId())
+                .build();
+        userOauth2ProvidersMapper.insertUserProvider(providerDto);
+    }
+
+    /**
+     * 사용자 속성을 캡슐화하는 클래스
+     */
+    private static class UserAttributes {
+        private final String email;
+        private final String name;
+        private final String oauth2Provider;
+        private final String oauth2ProviderId;
+
+        public UserAttributes(String email, String name, String oauth2Provider, String oauth2ProviderId) {
+            this.email = email;
+            this.name = name;
+            this.oauth2Provider = oauth2Provider;
+            this.oauth2ProviderId = oauth2ProviderId;
         }
 
-        // JWT 토큰 생성
-        CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
-        String jwtToken = jwtTokenUtil.generateToken(userDetails);
+        public String getEmail() {
+            return email;
+        }
 
-        // JWT 토큰을 사용자 정보에 추가
-        return new CustomOAuth2User(oAuth2User, jwtToken);
+        public String getName() {
+            return name;
+        }
+
+        public String getOauth2Provider() {
+            return oauth2Provider;
+        }
+
+        public String getOauth2ProviderId() {
+            return oauth2ProviderId;
+        }
     }
 }

--- a/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/tistory/framework/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,66 @@
+package com.tistory.framework.security.service;
+
+import com.tistory.framework.security.dto.CustomOAuth2User;
+import com.tistory.framework.security.dto.CustomUserDetails;
+import com.tistory.framework.security.utils.JwtTokenUtil;
+import com.tistory.project_api.dto.UserDto;
+import com.tistory.project_api.mapper.UserMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    @Autowired
+    UserMapper userMapper;
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    // OAuth2 로그인 후 사용자 정보를 로드
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 구글 OAuth2 제공자 ID 가져오기
+        String oauth2Provider = userRequest.getClientRegistration().getRegistrationId();
+        String oauth2ProviderId = oAuth2User.getName();
+
+        // 사용자 정보를 가져와서 데이터베이스에 저장
+        String email = oAuth2User.getAttribute("email");
+        String name = oAuth2User.getAttribute("name");
+
+        // 사용자 정보 저장 또는 업데이트
+        UserDto.UserBase user = userMapper.findByEmail(UserDto.UserSearchByEmailCondition.builder()
+                .email(email).build());
+        if (user == null) {
+            UserDto.SocialSignUp dto = UserDto.SocialSignUp.builder()
+                    .username(name)
+                    .email(email)
+                    .oauth2Provider(oauth2Provider)
+                    .oauth2ProviderId(oauth2ProviderId)
+                    .build();
+            userMapper.socialSignUp(dto);
+        } else {
+            // 기존 사용자 업데이트
+
+        }
+
+        // JWT 토큰 생성
+        CustomUserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        String jwtToken = jwtTokenUtil.generateToken(userDetails);
+
+        log.error("@@CustomOAuth2UserService jwtToken:{}", jwtToken);
+        // JWT 토큰을 사용자 정보에 추가
+        return new CustomOAuth2User(oAuth2User, jwtToken);
+
+    }
+}

--- a/src/main/java/com/tistory/project_api/ProjectApiApplication.java
+++ b/src/main/java/com/tistory/project_api/ProjectApiApplication.java
@@ -12,8 +12,7 @@ public class ProjectApiApplication {
 	public static void main(String[] args) {
 		SpringApplication app = new SpringApplicationBuilder(ProjectApiApplication.class).properties(
 				"spring.config.location="
-				+"classpath:/application.yml"
-				+", classpath:/config/database.yml")
+				+"classpath:/application.yml")
 				.build();
 		app.run(args);
 	}

--- a/src/main/java/com/tistory/project_api/dto/UserDto.java
+++ b/src/main/java/com/tistory/project_api/dto/UserDto.java
@@ -28,8 +28,6 @@ public class UserDto {
         private String email;
         private boolean enabled;
         private String role;
-        private String oauth2Provider;
-        private String oauth2ProviderId;
         private String createdAt;
         private String updatedAt;
     }
@@ -51,30 +49,6 @@ public class UserDto {
             setEmail(email);
             setEnabled(enabled);
             setRole(role);
-            setCreatedAt(createdAt);
-            setUpdatedAt(updatedAt);
-        }
-    }
-
-    @Data
-    public static class SocialSignUp extends UserSocialBase {
-        @Builder
-        public SocialSignUp(String id,
-                            String username,
-                            String email,
-                            boolean enabled,
-                            String role,
-                            String oauth2Provider,
-                            String oauth2ProviderId,
-                            String createdAt,
-                            String updatedAt) {
-            setId(id);
-            setUsername(username);
-            setEmail(email);
-            setEnabled(enabled);
-            setRole(role);
-            setOauth2Provider(oauth2Provider);
-            setOauth2ProviderId(oauth2ProviderId);
             setCreatedAt(createdAt);
             setUpdatedAt(updatedAt);
         }

--- a/src/main/java/com/tistory/project_api/dto/UserDto.java
+++ b/src/main/java/com/tistory/project_api/dto/UserDto.java
@@ -21,6 +21,18 @@ public class UserDto {
         private String updatedAt;
     }
 
+    @Data
+    public static class UserSocialBase {
+        private String id;
+        private String username;
+        private String email;
+        private boolean enabled;
+        private String role;
+        private String oauth2Provider;
+        private String oauth2ProviderId;
+        private String createdAt;
+        private String updatedAt;
+    }
 
     @Data
     public static class SignUp extends UserBase{
@@ -39,6 +51,30 @@ public class UserDto {
             setEmail(email);
             setEnabled(enabled);
             setRole(role);
+            setCreatedAt(createdAt);
+            setUpdatedAt(updatedAt);
+        }
+    }
+
+    @Data
+    public static class SocialSignUp extends UserSocialBase {
+        @Builder
+        public SocialSignUp(String id,
+                            String username,
+                            String email,
+                            boolean enabled,
+                            String role,
+                            String oauth2Provider,
+                            String oauth2ProviderId,
+                            String createdAt,
+                            String updatedAt) {
+            setId(id);
+            setUsername(username);
+            setEmail(email);
+            setEnabled(enabled);
+            setRole(role);
+            setOauth2Provider(oauth2Provider);
+            setOauth2ProviderId(oauth2ProviderId);
             setCreatedAt(createdAt);
             setUpdatedAt(updatedAt);
         }

--- a/src/main/java/com/tistory/project_api/dto/UserOauth2ProvidersDto.java
+++ b/src/main/java/com/tistory/project_api/dto/UserOauth2ProvidersDto.java
@@ -1,0 +1,50 @@
+package com.tistory.project_api.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserOauth2ProvidersDto {
+
+    @Data
+    public static class UserOauth2ProviderBase {
+        private String email;
+        private String provider;
+        private String providerId;
+        private String createdAt;
+        private String updatedAt;
+    }
+
+    @Data
+    public static class AddUserOauth2Provider extends UserOauth2ProviderBase{
+        @Builder
+        public AddUserOauth2Provider(String email,
+                                     String provider,
+                                     String providerId,
+                                     String createdAt,
+                                     String updatedAt) {
+            setEmail(email);
+            setProvider(provider);
+            setProviderId(providerId);
+            setCreatedAt(createdAt);
+            setUpdatedAt(updatedAt);
+        }
+
+    }
+
+
+
+    @Data
+    public static class UserProviderCondition {
+        private String email;
+        private String provider;
+        @Builder
+        public UserProviderCondition(String email,
+                                     String provider) {
+            setEmail(email);
+            setProvider(provider);
+        }
+    }
+}

--- a/src/main/java/com/tistory/project_api/mapper/UserMapper.java
+++ b/src/main/java/com/tistory/project_api/mapper/UserMapper.java
@@ -12,4 +12,8 @@ public interface UserMapper {
     int signUp(UserDto.SignUp param);
 
     UserDto.UserBase findByEmail(UserDto.UserSearchByEmailCondition param);
+
+
+    // oauth2 소셜 로그인 기반 회원가입
+    int socialSignUp(UserDto.SocialSignUp param);
 }

--- a/src/main/java/com/tistory/project_api/mapper/UserMapper.java
+++ b/src/main/java/com/tistory/project_api/mapper/UserMapper.java
@@ -13,7 +13,4 @@ public interface UserMapper {
 
     UserDto.UserBase findByEmail(UserDto.UserSearchByEmailCondition param);
 
-
-    // oauth2 소셜 로그인 기반 회원가입
-    int socialSignUp(UserDto.SocialSignUp param);
 }

--- a/src/main/java/com/tistory/project_api/mapper/UserOauth2ProvidersMapper.java
+++ b/src/main/java/com/tistory/project_api/mapper/UserOauth2ProvidersMapper.java
@@ -1,0 +1,11 @@
+package com.tistory.project_api.mapper;
+
+import com.tistory.project_api.dto.UserOauth2ProvidersDto;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserOauth2ProvidersMapper {
+    int insertUserProvider(UserOauth2ProvidersDto.AddUserOauth2Provider param);
+
+    UserOauth2ProvidersDto.UserOauth2ProviderBase findByEmailProvider(UserOauth2ProvidersDto.UserProviderCondition param);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,3 @@ mybatis:
 
 logging:
   config: classpath:config/logback-spring.xml
-
-secret:
-  key:
-    path: classpath:secret.key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: project-api
+  config:
+    import:
+      - config/database.yml
+      - config/security.yml
 
 mybatis:
   config-location: classpath:mybatis/mybatis-config.xml

--- a/src/main/resources/config/security.yml
+++ b/src/main/resources/config/security.yml
@@ -14,3 +14,8 @@ spring:
             token-uri: https://oauth2.googleapis.com/token # 액세스 토큰을 발급받기 위한 URI
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo # 사용자 정보를 가져오기 위한 URI
             user-name-attribute: sub # 사용자 정보에서 사용자 이름으로 사용할 속성
+
+
+secret:
+  key:
+    path: classpath:keys/secret.key

--- a/src/main/resources/config/security.yml
+++ b/src/main/resources/config/security.yml
@@ -1,0 +1,16 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile, email
+            redirect-uri: http://localhost:8080/login/oauth2/code/google # 인증 후 사용자가 리디렉션될 URI
+        provider: # OAuth 2.0 제공자의 엔드포인트를 정의
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth # 사용자를 인증하기 위한 URI
+            token-uri: https://oauth2.googleapis.com/token # 액세스 토큰을 발급받기 위한 URI
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo # 사용자 정보를 가져오기 위한 URI
+            user-name-attribute: sub # 사용자 정보에서 사용자 이름으로 사용할 속성

--- a/src/main/resources/config/security.yml
+++ b/src/main/resources/config/security.yml
@@ -8,12 +8,42 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile, email
             redirect-uri: http://localhost:8080/login/oauth2/code/google # 인증 후 사용자가 리디렉션될 URI
+            client-name: Google
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            client-authentication-method: client_secret_post # post가 아닌 client_secret_post로 설정해줘야함!
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            scope: profile
+            client-name: Naver
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, profile_image, account_email
+            client-name: Kakao
         provider: # OAuth 2.0 제공자의 엔드포인트를 정의
           google:
             authorization-uri: https://accounts.google.com/o/oauth2/auth # 사용자를 인증하기 위한 URI
             token-uri: https://oauth2.googleapis.com/token # 액세스 토큰을 발급받기 위한 URI
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo # 사용자 정보를 가져오기 위한 URI
             user-name-attribute: sub # 사용자 정보에서 사용자 이름으로 사용할 속성
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token_uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user_name_attribute: id
+
+
+
 
 
 secret:

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -32,17 +32,4 @@
         FROM user
         WHERE email = #{email}
     </select>
-
-    <insert id="socialSignUp"
-            parameterType="com.tistory.project_api.dto.UserDto$SocialSignUp">
-        <selectKey keyProperty="id" resultType="string" order="BEFORE">
-            SELECT CONCAT('U', DATE_FORMAT(NOW(), '%y%m%d'),
-            LPAD(CAST(COALESCE(MAX(CAST(SUBSTRING(id, 8) AS UNSIGNED)), 0) + 1 AS CHAR), 6, '0')) AS id
-            FROM user
-            WHERE SUBSTRING(id, 2, 6) = DATE_FORMAT(NOW(), '%y%m%d');
-        </selectKey>
-
-        INSERT INTO USER (id, username, email, enabled, role, oauth2_provider, oauth2_provider_id, created_at, updated_at)
-        VALUES (#{id}, #{username}, #{email}, true, 'user', #{oauth2Provider}, #{oauth2ProviderId}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-    </insert>
 </mapper>

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -32,4 +32,17 @@
         FROM user
         WHERE email = #{email}
     </select>
+
+    <insert id="socialSignUp"
+            parameterType="com.tistory.project_api.dto.UserDto$SocialSignUp">
+        <selectKey keyProperty="id" resultType="string" order="BEFORE">
+            SELECT CONCAT('U', DATE_FORMAT(NOW(), '%y%m%d'),
+            LPAD(CAST(COALESCE(MAX(CAST(SUBSTRING(id, 8) AS UNSIGNED)), 0) + 1 AS CHAR), 6, '0')) AS id
+            FROM user
+            WHERE SUBSTRING(id, 2, 6) = DATE_FORMAT(NOW(), '%y%m%d');
+        </selectKey>
+
+        INSERT INTO USER (id, username, email, enabled, role, oauth2_provider, oauth2_provider_id, created_at, updated_at)
+        VALUES (#{id}, #{username}, #{email}, true, 'user', #{oauth2Provider}, #{oauth2ProviderId}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    </insert>
 </mapper>

--- a/src/main/resources/mybatis/mappers/UserOauth2ProvidersMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserOauth2ProvidersMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.tistory.project_api.mapper.UserOauth2ProvidersMapper">
+    <insert id="insertUserProvider"
+            parameterType="com.tistory.project_api.dto.UserOauth2ProvidersDto$AddUserOauth2Provider">
+        INSERT INTO USER_OAUTH2_PROVIDERS(email, provider, provider_id, created_at, updated_at)
+        VALUES (#{email}, #{provider}, #{providerId}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    </insert>
+
+    <select id="findByEmailProvider"
+            parameterType="com.tistory.project_api.dto.UserOauth2ProvidersDto$UserProviderCondition"
+            resultType="com.tistory.project_api.dto.UserOauth2ProvidersDto$UserOauth2ProviderBase">
+        SELECT email, provider, created_at, updated_at
+        FROM user_oauth2_providers
+        WHERE email = #{email} AND provider = #{provider}
+    </select>
+</mapper>

--- a/src/test/java/com/tistory/project_api/OAuth2LoginTest.java
+++ b/src/test/java/com/tistory/project_api/OAuth2LoginTest.java
@@ -1,0 +1,26 @@
+package com.tistory.project_api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class OAuth2LoginTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testOAuth2Login() throws Exception {
+        mockMvc.perform(get("/oauth2/authorization/google")
+                        .with(SecurityMockMvcRequestPostProcessors.user("user").roles("USER")))
+                .andExpect(status().is3xxRedirection());
+    }
+}


### PR DESCRIPTION
> - **[Spring Security 6.x로 소셜 로그인 구현하기 (oauth2)](https://tyan-8.tistory.com/29)**
- GOOGLE, NAVER, KAKAO 소셜 로그인 구현
- 회원가입시 기존에 가입된 사용자일 경우 처리해주기위해 user테이블과 user_oauth2_providers 테이블을 사용해 소셜 로그인 통합 관리
<details>
<summary>CustomOAuth2UserService의 플로우는 첨부된 이미지와 같습니다.</summary>
<div markdown="1">
<img width="300" alt="스크린샷 2024-06-09 오후 6 09 48" src="https://github.com/a-taeyeon/springboot-tistory-example/assets/53987550/96bbdac4-3865-4a72-89ad-82a211e11d6c">
</div>
</details>
